### PR TITLE
Disable TCP slow start after idle

### DIFF
--- a/sysctl.conf
+++ b/sysctl.conf
@@ -3,7 +3,7 @@
 # Contributor: IceCodeNew
 # Contributor: HorlogeSkynet
 # Date Created: October 5, 2020
-# Last Updated: June 7, 2021
+# Last Updated: October 12, 2021
 
 # Licensed under the GNU General Public License Version 3 (GNU GPL v3),
 #   available at: https://www.gnu.org/licenses/gpl-3.0.txt
@@ -215,14 +215,10 @@ net.ipv4.ip_local_port_range = 1024 65535
 # - 2: enable timestamps without random offsets
 net.ipv4.tcp_timestamps = 0
 
-# Refer to: https://dropbox.tech/infrastructure/optimizing-web-servers-for-high-throughput-and-low-latency
-# the main problem with slowstart after idle is that “idle” is defined as one RTO, which is too small.
-# Refer to: https://hpbn.co/building-blocks-of-tcp/#slow-start-restart
-# Not surprisingly, SSR can have a significant impact on performance of long-lived TCP connections that may idle for bursts of time — e.g., due to user inactivity.
-# As a result, it is generally recommended to disable SSR on the server to help improve performance of long-lived HTTP connections.
-# Refer to: https://github.com/httpwg/http2-spec/wiki/Ops
-# This drops cwnd back down to initcwnd and goes back to slow start after the connection has been “idle” (defined as the RTO). This kills persistent single connection performance and should be turned off.
-net.ipv4.tcp_slow_start_after_idle = 0
+# SSR could impact TCP's performance on a fixed-speed network (e.g., wired)
+#   but it could be helpful on a variable-speed network (e.g., LTE)
+# uncomment this if you are on a fixed-speed network
+#net.ipv4.tcp_slow_start_after_idle = 0
 
 # enabling SACK can increase the throughput
 # but SACK is commonly exploited and rarely used


### PR DESCRIPTION
### Refer to: https://dropbox.tech/infrastructure/optimizing-web-servers-for-high-throughput-and-low-latency
> the main problem with slowstart after idle is that “idle” is defined as one RTO, which is too small.
### Refer to: https://hpbn.co/building-blocks-of-tcp/#slow-start-restart
> Not surprisingly, SSR can have a significant impact on performance of long-lived TCP connections that may idle for bursts of time — e.g., due to user inactivity.
> As a result, it is generally recommended to disable SSR on the server to help improve performance of long-lived HTTP connections.
### Refer to: https://github.com/httpwg/http2-spec/wiki/Ops
> This drops cwnd back down to initcwnd and goes back to slow start after the connection has been “idle” (defined as the RTO). This kills persistent single connection performance and should be turned off.

Signed-off-by: IceCodeNew <32576256+IceCodeNew@users.noreply.github.com>