### PR TITLE
Mentions `kernel.yama.ptrace_scope = 3` breaks lxc v6+ procfs

### DIFF
--- a/sysctl.conf
+++ b/sysctl.conf
@@ -42,6 +42,8 @@ kernel.kptr_restrict = 2
 #   - 1: only a parent process can be debugged
 #   - 2: only admins can use ptrace (CAP_SYS_PTRACE capability required)
 #   - 3: disables ptrace completely, reboot is required to re-enable ptrace
+# be aware disabling ptrace completely breaks lxc v6+ procfs emulation for unprivileged containers
+# (see https://github.com/lxc/lxcfs/issues/636)
 kernel.yama.ptrace_scope = 3
 
 # restrict kernel logs to root only

--- a/sysctl.conf
+++ b/sysctl.conf
@@ -4,11 +4,11 @@
 # Contributor: HorlogeSkynet
 # Contributor: shenzhui007
 # Date Created: October 5, 2020
-# Last Updated: July 6, 2023
+# Last Updated: May 2, 2024
 
 # Licensed under the GNU General Public License Version 3 (GNU GPL v3),
 #   available at: https://www.gnu.org/licenses/gpl-3.0.txt
-# (C) 2020-2023 K4YT3X
+# (C) 2020-2024 K4YT3X
 
 # Multiple sources have been consulted while writing this configuration
 #  file (e.g., nixCraft's sysctl.conf). Sources are not cited since this
@@ -39,11 +39,15 @@ kernel.core_uses_pid = 1
 kernel.kptr_restrict = 2
 
 # Ptrace protection using Yama
-#   - 1: only a parent process can be debugged
-#   - 2: only admins can use ptrace (CAP_SYS_PTRACE capability required)
-#   - 3: disables ptrace completely, reboot is required to re-enable ptrace
-# be aware disabling ptrace completely breaks lxc v6+ procfs emulation for unprivileged containers
-# (see https://github.com/lxc/lxcfs/issues/636)
+#   - 0 (classic): allows any process to trace any other process under the same UID
+#   - 1 (restricted): only a parent process can be debugged
+#   - 2 (admin-only): only admins can use ptrace (CAP_SYS_PTRACE capability required)
+#   - 3 (no attach): disables ptrace completely, reboot is required to re-enable ptrace
+# the general recommendation for this setting is:
+#   - if you do not need to debug programs, set it to 3
+#   - if you need to debug programs (e.g., GDB, LLDB, strace), set it to 1
+# setting it to 3 will also break LXC v6+ procfs emulation for unprivileged containers
+#   (see GitHub issue https://github.com/lxc/lxcfs/issues/636)
 kernel.yama.ptrace_scope = 3
 
 # restrict kernel logs to root only


### PR DESCRIPTION
Hello @k4yt3x :wave:

I've been recently struggling with this, and as lxc (unprivileged) containers are widely used to isolate some environments, I wondered whether this mention could be included here (as default Yama ptrace scope of `3` definitely breaks procfs emulation, and could not be reverted without a reboot...).

Thanks for your time, bye :wave:

---

> Upstream issue : lxc/lxcfs#636
> Upstream mitigation (this is not a fix) : lxc/lxcfs#639
